### PR TITLE
Add Envio to indexing options

### DIFF
--- a/docs/getting-started/starting-with-development.mdx
+++ b/docs/getting-started/starting-with-development.mdx
@@ -290,6 +290,7 @@ Tools like **Ethers.js** and **The Graph** allow real-time monitoring.
    });
    ```
 
+- **Envio**, the data layer for blockchain apps, natively supports indexing any EVM chain out of the box, including Bitfinity, using your own RPC as the data source. Learn more at [envio.dev](https://envio.dev/?utm_source=bitfinity&utm_medium=partner-docs).
 - **The Graph**: A decentralized indexing protocol, ideal for querying and responding to event data.
 
 Using events effectively enables interactive applications that react to blockchain changes in real time.


### PR DESCRIPTION
Adds Envio alongside the existing indexing options for monitoring event data. Envio's HyperIndex natively supports indexing any EVM chain out of the box, including Bitfinity, using your own RPC as the data source.